### PR TITLE
Bug 396887 - arch_prctl should return EINVAL on unknown option.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,31 @@
+Release 3.14.ab (?? ????????? 201?)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~--
+Release 3.14.ab is under development, not yet released.
+
+3.14.ab is not a release at all. Here is just a cherry picked from origin
+project.
+
+This release supports X86/Linux, AMD64/Linux, ARM32/Linux, ARM64/Linux,
+PPC32/Linux, PPC64BE/Linux, PPC64LE/Linux, S390X/Linux, MIPS32/Linux,
+MIPS64/Linux, ARM/Android, ARM64/Android, MIPS32/Android, X86/Android,
+X86/Solaris, AMD64/Solaris and AMD64/MacOSX 10.12. There is also preliminary
+support for X86/macOS 10.13, AMD64/macOS 10.13.
+
+* ==================== FIXED BUGS ====================
+
+The following bugs have been fixed or resolved.  Note that "n-i-bz"
+stands for "not in bugzilla" -- that is, a bug that was reported to us
+but never got a bugzilla entry.  We encourage you to file bugs in
+bugzilla (https://bugs.kde.org/enter_bug.cgi?product=valgrind) rather
+than mailing the developers (or mailing lists) directly -- bugs that
+are not entered into bugzilla tend to get forgotten about or ignored.
+
+To see details of a given bug, visit
+  https://bugs.kde.org/show_bug.cgi?id=XXXXXX
+where XXXXXX is the bug number as listed below.
+
+396887  arch_prctl should return EINVAL on unknown option
+
 Release 3.13.0 (15 June 2017)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/coregrind/m_syswrap/syswrap-amd64-linux.c
+++ b/coregrind/m_syswrap/syswrap-amd64-linux.c
@@ -249,6 +249,7 @@ PRE(sys_rt_sigreturn)
 PRE(sys_arch_prctl)
 {
    ThreadState* tst;
+   Bool known_option = True;
    PRINT( "arch_prctl ( %ld, %lx )", SARG1, ARG2 );
 
    vg_assert(VG_(is_valid_tid)(tid));
@@ -283,13 +284,16 @@ PRE(sys_arch_prctl)
       POST_MEM_WRITE(ARG2, sizeof(unsigned long));
    }
    else {
-      VG_(core_panic)("Unsupported arch_prctl option");
+      known_option = False;
    }
 
    /* Note; the Status writeback to guest state that happens after
       this wrapper returns does not change guest_FS_CONST or guest_GS_CONST;
       hence that direct assignment to the guest state is safe here. */
-   SET_STATUS_Success( 0 );
+   if (known_option)
+      SET_STATUS_Success( 0 );
+   else
+      SET_STATUS_Failure( VKI_EINVAL );
 }
 
 // Parts of this are amd64-specific, but the *PEEK* cases are generic.


### PR DESCRIPTION
This is just a cherry-pick of commit 21a01b13e259b9a43f10f0046b2b3f409c11ea75

Currently arch_prctl calls VG_(core_panic) when it sees an unknown
arch_prctl option which kills the process. glibc uses arch_prctl with
an (as yet) unknown option to see if the kernel supports CET. This
breaks any application running under valgrind on x86_64 with:

valgrind: the 'impossible' happened:
   Unsupported arch_prctl option

Thread 1: status = VgTs_Runnable (lwpid 19934)
==19934==    at 0x121A15: get_cet_status (cpu-features.c:28)
==19934==    by 0x121A15: init_cpu_features (cpu-features.c:474)
==19934==    by 0x121A15: dl_platform_init (dl-machine.h:228)
==19934==    by 0x121A15: _dl_sysdep_start (dl-sysdep.c:231)
==19934==    by 0x10A1D7: _dl_start_final (rtld.c:413)
==19934==    by 0x10A1D7: _dl_start (rtld.c:520)

We already handle all known options. It would be better to do as the
kernel does and just return failure with EINVAL instead.